### PR TITLE
Locks aws-sdk version to be less than 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.0.3
+- Ensures `aws-sdk` gem is version 1
+- adds byebug for future development
+
 ### v0.0.2
 - Fixes gemspec validation issues
 

--- a/lib/rotator/uploaders/s3.rb
+++ b/lib/rotator/uploaders/s3.rb
@@ -29,7 +29,7 @@ module Rotator
         ) if opts.nil?
         self.bucket = opts.delete(:bucket) || opts.delete("bucket") || "#{get_hostname}.rotator.files"
         @s3_options = opts
-        @connection = AWS::S3.new(s3_options)
+        @connection = ::AWS::S3.new(s3_options)
       end
 
       def create_bucket

--- a/lib/rotator/version.rb
+++ b/lib/rotator/version.rb
@@ -1,3 +1,3 @@
 module Rotator
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/rotator.gemspec
+++ b/rotator.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"
-  s.add_runtime_dependency "aws-sdk"
+  s.add_development_dependency "byebug"
+  s.add_runtime_dependency "aws-sdk", '~> 1.66.0', '< 2.0.0'
 end


### PR DESCRIPTION
Fixes rotator bug for `uninitialized constant Rotator::Uploaders::S3::AWS`
